### PR TITLE
Edits to Character Dialogue

### DIFF
--- a/maps/GoldenrodCity.asm
+++ b/maps/GoldenrodCity.asm
@@ -299,13 +299,13 @@ GoldenrodCityYoungster1Text:
 
 GoldenrodCityCooltrainerF1Text:
 	text "Earlier today I"
-	line "went to the dept"
+	line "went to the DEPT."
 
-	para "store and bought a"
-	line "moon stone, then"
+	para "STORE and bought a"
+	line "MOON STONE. Then"
 
-	para "my eevee evolved"
-	line "into Umbreon!"
+	para "my EEVEE evolved"
+	line "into UMBREON!"
 	done
 
 GoldenrodCityCooltrainerF1Text_ClearedRadioTower:

--- a/maps/VioletGym.asm
+++ b/maps/VioletGym.asm
@@ -173,9 +173,9 @@ UnknownText_0x68648:
 	para "instantly learn a"
 	line "new move."
 
-	para "Think before you"
-	line "act--a TM can be"
-	cont "used only once."
+	para "And you can use"
+	line "a TM over and over."
+	cont "They don't run out."
 
 	para "TM31 contains"
 	line "MUD-SLAP."


### PR DESCRIPTION
**Why this change is needed:** The edits and rewrites in this commit explain that TMs are now reusable, rewriting the old dialogue to match the new mechanics.

It also adjusts new information about evolution stones to match the style guide of the Pokemon Crystal dialogue: Pokemon names, Key Places, and Item names in all caps with no lower case.

**Notes for reviewers:** Hi! My name is Joe, I am a Technical Writer and Editor. I have tried out your
work on Pokemon Crystal 2.0 and am enjoying the quality of life changes.

With these changes, I have not been able to rebuild the .maps or other key files with the make commands. It returns a "Version 6 object file" incompatible error. Please feel free to delete the change if they will break the game files, and I can try to solve the error and send the changes again.